### PR TITLE
Fix clean filter failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 services:
   - docker

--- a/src/main/java/org/lsc/plugins/connectors/msgraphapi/MsGraphApiDao.java
+++ b/src/main/java/org/lsc/plugins/connectors/msgraphapi/MsGraphApiDao.java
@@ -200,7 +200,7 @@ public class MsGraphApiDao {
     }
 
     public Optional<User> getFirstUserWithId(String pivotValue) {
-        String pivotFilter = pivot + " eq '" + pivotValue + "'";
+        String pivotFilter = pivot + " eq '" + pivotValue.replaceAll("'", "''") + "'";
         String computedFilter = filter.map(f -> "(" + f + ")" + " and " + pivotFilter)
             .orElse(pivotFilter);
         return getUsersList(Optional.of(computedFilter))

--- a/src/main/java/org/lsc/plugins/connectors/msgraphapi/MsGraphApiDao.java
+++ b/src/main/java/org/lsc/plugins/connectors/msgraphapi/MsGraphApiDao.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -105,7 +106,7 @@ public class MsGraphApiDao {
         return getUsersList(filter);
     }
 
-    private List<User> getUsersList(Optional<String> computedFilter) throws LscServiceException {
+    private List<User> getUsersList(Optional<String> computedFilter) {
         WebTarget target = pivot.equals(ID) ? usersClient.queryParam("$select", pivot) : usersClient.queryParam("$select","id," + pivot);
 
         if (computedFilter.isPresent()) {
@@ -141,7 +142,7 @@ public class MsGraphApiDao {
         return true;
     }
 
-    private UsersListResponse getUsersListResponse(WebTarget target) throws LscServiceException {
+    private UsersListResponse getUsersListResponse(WebTarget target) {
         LOGGER.debug("GETting users list or following page: " + target.getUri().toString());
 
         Response response = null;
@@ -156,7 +157,7 @@ public class MsGraphApiDao {
             if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
                 throw new NotFoundException("Not found when requesting " + target.getUri());
             }
-            throw new LscServiceException(response.readEntity(String.class));
+            throw new ProcessingException(response.readEntity(String.class));
         } finally {
             if (response != null) {
                 response.close();
@@ -168,7 +169,7 @@ public class MsGraphApiDao {
         return Response.Status.Family.familyOf(response.getStatus()) == Response.Status.Family.SUCCESSFUL;
     }
 
-    public Map<String, Object> getUserDetails(String id) throws LscServiceException {
+    public Map<String, Object> getUserDetails(String id) {
 
         Response response = null;
         try {
@@ -189,7 +190,7 @@ public class MsGraphApiDao {
             if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
                 throw new NotFoundException(id + " cannot be found");
             }
-            throw new LscServiceException(response.readEntity(String.class));
+            throw new ProcessingException(response.readEntity(String.class));
         } finally {
             if (response != null) {
                 response.close();
@@ -198,7 +199,7 @@ public class MsGraphApiDao {
 
     }
 
-    public Optional<User> getFirstUserWithId(String pivotValue) throws LscServiceException {
+    public Optional<User> getFirstUserWithId(String pivotValue) {
         String pivotFilter = pivot + " eq '" + pivotValue + "'";
         String computedFilter = filter.map(f -> "(" + f + ")" + " and " + pivotFilter)
             .orElse(pivotFilter);

--- a/src/test/java/org/lsc/plugins/connectors/msgraphapi/MsGraphApiUsersServiceTest.java
+++ b/src/test/java/org/lsc/plugins/connectors/msgraphapi/MsGraphApiUsersServiceTest.java
@@ -43,6 +43,7 @@
 package org.lsc.plugins.connectors.msgraphapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
@@ -392,11 +393,22 @@ class MsGraphApiUsersServiceTest {
     }
 
     @Test
-    void getBeanShouldThrowAnLscExceptionWithACauseDifferentThanACommunicationExceptionWhenMalformedPivot() throws Exception {
+    void getBeanShouldNotThrowWhenNonExistingUserFromAnotherServiceWithSingleQuoteAndIdPivot() throws Exception {
         when(usersService.getPivot()).thenReturn("id");
         MsGraphApiUsersSrcService testee = new MsGraphApiUsersSrcService(task);
 
         LscDatasets datasets = new LscDatasets(ImmutableMap.of("id", "us'er@test"));
+
+        assertThatCode(() -> testee.getBean("mainIdentifierFromDestinationService", datasets, !FROM_SAME_SERVICE))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void getBeanShouldThrowAnLscExceptionWithACauseDifferentThanACommunicationExceptionWhenMalformedPivot() throws Exception {
+        when(usersService.getPivot()).thenReturn("id");
+        MsGraphApiUsersSrcService testee = new MsGraphApiUsersSrcService(task);
+
+        LscDatasets datasets = new LscDatasets(ImmutableMap.of("id", "us%27er@test"));
 
         assertThatThrownBy(() -> testee.getBean("mainIdentifierFromDestinationService", datasets, !FROM_SAME_SERVICE))
             .isInstanceOf(LscServiceException.class)

--- a/src/test/java/org/lsc/plugins/connectors/msgraphapi/MsGraphApiUsersServiceTest.java
+++ b/src/test/java/org/lsc/plugins/connectors/msgraphapi/MsGraphApiUsersServiceTest.java
@@ -50,6 +50,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
+import javax.naming.CommunicationException;
+
 import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -387,6 +389,20 @@ class MsGraphApiUsersServiceTest {
         IBean bean = testee.getBean("mainIdentifierFromDestinationService", datasets, !FROM_SAME_SERVICE);
 
         assertThat(bean).isNull();
+    }
+
+    @Test
+    void getBeanShouldThrowAnLscExceptionWithACauseDifferentThanACommunicationExceptionWhenMalformedPivot() throws Exception {
+        when(usersService.getPivot()).thenReturn("id");
+        MsGraphApiUsersSrcService testee = new MsGraphApiUsersSrcService(task);
+
+        LscDatasets datasets = new LscDatasets(ImmutableMap.of("id", "us'er@test"));
+
+        assertThatThrownBy(() -> testee.getBean("mainIdentifierFromDestinationService", datasets, !FROM_SAME_SERVICE))
+            .isInstanceOf(LscServiceException.class)
+            .extracting(e -> e.getCause())
+            .isNotNull()
+            .isNotInstanceOf(CommunicationException.class);
     }
 
     @Test


### PR DESCRIPTION
Fix for #1 
When the filter is not valid during a getBean from external service we now throw LscServiceException with a non null cause which don't make the clean filter halt.

And we now protect single quote with a second one like defined in the RFC :
http://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_URLComponents