### PR TITLE
Bumping XSD schema to LSC Core 2.2 to help with compatibility

### DIFF
--- a/sample/msgraphapi-to-ldap-advanced/lsc.xml
+++ b/sample/msgraphapi-to-ldap-advanced/lsc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<lsc xmlns="http://lsc-project.org/XSD/lsc-core-2.1.xsd"
+<lsc xmlns="http://lsc-project.org/XSD/lsc-core-2.2.xsd"
      xmlns:msgraphapi="http://lsc-project.org/XSD/lsc-microsoft-graph-api-plugin-1.0.xsd" revision="0">
     <connections>
         <ldapConnection>

--- a/sample/msgraphapi-to-ldap/lsc.xml
+++ b/sample/msgraphapi-to-ldap/lsc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<lsc xmlns="http://lsc-project.org/XSD/lsc-core-2.1.xsd"
+<lsc xmlns="http://lsc-project.org/XSD/lsc-core-2.2.xsd"
      xmlns:msgraphapi="http://lsc-project.org/XSD/lsc-microsoft-graph-api-plugin-1.0.xsd" revision="0">
     <connections>
         <ldapConnection>

--- a/src/main/java/org/lsc/plugins/connectors/msgraphapi/generated/MsGraphApiService.java
+++ b/src/main/java/org/lsc/plugins/connectors/msgraphapi/generated/MsGraphApiService.java
@@ -24,7 +24,7 @@ import org.lsc.configuration.ServiceType;
  * <pre>
  * &lt;complexType name="msGraphApiService">
  *   &lt;complexContent>
- *     &lt;extension base="{http://lsc-project.org/XSD/lsc-core-2.1.xsd}serviceType">
+ *     &lt;extension base="{http://lsc-project.org/XSD/lsc-core-2.2.xsd}serviceType">
  *     &lt;/extension>
  *   &lt;/complexContent>
  * &lt;/complexType>

--- a/src/main/java/org/lsc/plugins/connectors/msgraphapi/generated/package-info.java
+++ b/src/main/java/org/lsc/plugins/connectors/msgraphapi/generated/package-info.java
@@ -5,5 +5,5 @@
 // Generated on: 2019.11.29 at 11:43:47 AM CET 
 //
 
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://lsc-project.org/XSD/lsc-core-2.1.xsd", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://lsc-project.org/XSD/lsc-core-2.2.xsd", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.lsc.plugins.connectors.msgraphapi.generated;

--- a/src/main/resources/schemas/lsc-core-2.2.xsd
+++ b/src/main/resources/schemas/lsc-core-2.2.xsd
@@ -42,14 +42,14 @@
  *         Sebastien Bahloul <seb@lsc-project.org>
  ****************************************************************************
  -->
- <!-- 
+<!-- 
  	Changelog:
  	- 02/05/2012: nisConnectionType and nisServiceType have been moved to dedicated XSD file inside the corresponding plugin
  		No new version is released because it has never been implemented before and won't break any existing and functional configuration
-  -->
+-->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
-	xmlns="http://lsc-project.org/XSD/lsc-core-2.1.xsd"
-	targetNamespace="http://lsc-project.org/XSD/lsc-core-2.1.xsd"
+	xmlns="http://lsc-project.org/XSD/lsc-core-2.2.xsd"
+	targetNamespace="http://lsc-project.org/XSD/lsc-core-2.2.xsd"
 	elementFormDefault="qualified"
 	xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
 	jaxb:version="2.0">
@@ -78,8 +78,8 @@
 
 	<xsd:simpleType name="ldapReferralType">
 		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="FOLLOW" />
 			<xsd:enumeration value="IGNORE" />
-			<xsd:enumeration value="THROUGH" />
 			<xsd:enumeration value="THROW" />
 			<xsd:enumeration value="ERROR" />
 		</xsd:restriction>
@@ -98,6 +98,14 @@
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="VERSION_2" />
 			<xsd:enumeration value="VERSION_3" />
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="saslQopType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="auth"/>
+			<xsd:enumeration value="auth-int"/>
+			<xsd:enumeration value="auth-conf"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 
@@ -128,6 +136,10 @@
 						minOccurs="0" />
 					<xsd:element name="recursiveDelete" type="xsd:boolean"
 						default="false" minOccurs="0" />
+					<xsd:element name="relaxRules" type="xsd:boolean"
+						default="false" minOccurs="0" />
+					<xsd:element name="saslQop" type="saslQopType"
+								 default="auth" minOccurs="0" />
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -140,14 +152,6 @@
 					<xsd:element name="driver" type="xsd:string" />
 				</xsd:sequence>
 			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-
-	<xsd:complexType name="googleAppsConnectionType">
-		<!-- URL should contain the domain name like domain.com as declared on 
-			google apps -->
-		<xsd:complexContent>
-			<xsd:extension base="connectionType" />
 		</xsd:complexContent>
 	</xsd:complexType>
 
@@ -182,59 +186,6 @@
 		<xsd:attribute name="id" type="xsd:string" use="optional" />
 	</xsd:complexType>
 
-	<xsd:complexType name="auditType">
-		<xsd:sequence>
-			<xsd:element name="name" type="xsd:ID" />
-			<xsd:element name="append" type="xsd:boolean" minOccurs="0"
-				default="true" />
-			<xsd:element name="operations" type="xsd:string"
-				minOccurs="0" />
-			<xsd:element name="file" type="xsd:string" />
-		</xsd:sequence>
-		<xsd:attribute name="id" type="xsd:string" use="optional" />
-	</xsd:complexType>
-
-	<xsd:complexType name="ldifAuditType">
-		<xsd:complexContent>
-			<xsd:extension base="auditType">
-				<xsd:sequence>
-					<xsd:element name="logOnlyLdif" type="xsd:boolean"
-						default="true" minOccurs="0" />
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-
-	<xsd:complexType name="csvAuditType">
-		<xsd:complexContent>
-			<xsd:extension base="auditType">
-				<xsd:sequence>
-					<xsd:element name="datasets" type="xsd:string"
-						minOccurs="0" />
-					<xsd:element name="separator" type="xsd:string"
-						minOccurs="0" default=";" />
-					<xsd:element name="outputHeader" type="xsd:boolean"
-						minOccurs="0" default="true" />
-					<xsd:element name="taskNames" type="valuesType"
-						minOccurs="0" />
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-
-	<xsd:complexType name="pluginAuditType">
-		<xsd:complexContent>
-			<xsd:extension base="auditType">
-				<xsd:sequence>
-					<xsd:any namespace="##any" minOccurs="0" maxOccurs="unbounded"
-						processContents="lax" />
-				</xsd:sequence>
-				<xsd:attribute name="configurationClass" type="xsd:string" />
-				<xsd:attribute name="implementationClass" type="xsd:string" />
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-
 	<xsd:complexType name="serviceType">
 		<xsd:sequence>
 			<xsd:element name="name" type="xsd:ID" />
@@ -255,6 +206,30 @@
 		</xsd:sequence>
 		<xsd:attribute name="id" type="xsd:string" use="optional" />
 	</xsd:complexType>
+	
+	<xsd:complexType name="pivotTransformationType">
+		<xsd:sequence>
+			<xsd:element name="transformation" minOccurs="0" maxOccurs="unbounded">
+				<xsd:complexType>
+					<xsd:simpleContent>
+						<xsd:extension base="xsd:string">
+							<xsd:attribute name="fromAttribute" type="xsd:string" />
+							<xsd:attribute name="toAttribute" type="xsd:string" />
+							<xsd:attribute name="pivotOrigin" type="pivotOriginType" use="optional" default="BOTH" />
+						</xsd:extension>
+					</xsd:simpleContent>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="pivotOriginType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SOURCE" />
+			<xsd:enumeration value="DESTINATION" />
+			<xsd:enumeration value="BOTH" />
+		</xsd:restriction>
+	</xsd:simpleType>
 
 	<xsd:complexType name="forceSyncOptionsType">
 		<xsd:complexContent>
@@ -296,16 +271,27 @@
 		</xsd:sequence>
 	</xsd:complexType>
 
+	<xsd:complexType name="hooksType">
+		<xsd:sequence>
+			<xsd:element name="outputFormat" type="xsd:string" minOccurs="0" />
+			<xsd:element name="createPostHook" type="xsd:string" minOccurs="0" />
+			<xsd:element name="updatePostHook" type="xsd:string" minOccurs="0" />
+			<xsd:element name="deletePostHook" type="xsd:string" minOccurs="0" />
+			<xsd:element name="changeIdPostHook" type="xsd:string" minOccurs="0" />
+		</xsd:sequence>
+	</xsd:complexType>
+
 	<xsd:complexType name="propertiesBasedSyncOptionsType">
 		<xsd:complexContent>
 			<xsd:extension base="syncOptionsType">
 				<xsd:sequence>
-					<xsd:element name="defaultDelimiter" type="xsd:string"
-						default=";" />
+					<xsd:element name="pivotTransformation" type="pivotTransformationType" minOccurs="0"/>
+					<xsd:element name="defaultDelimiter" type="xsd:string" />
 					<xsd:element name="defaultPolicy" type="policyType"
 						default="FORCE" />
 					<xsd:element name="conditions" type="conditionsType"
 						minOccurs="0" />
+					<xsd:element name="hooks" type="hooksType" minOccurs="0" />
 					<xsd:element name="dataset" type="datasetType"
 						minOccurs="0" maxOccurs="unbounded" />
 				</xsd:sequence>
@@ -383,8 +369,6 @@
 		<xsd:complexContent>
 			<xsd:extension base="ldapSourceServiceType">
 				<xsd:sequence>
-					<xsd:element name="synchronizingAllWhenStarting" type="xsd:boolean"
-						minOccurs="0" default="true" />
 					<xsd:element name="serverType" type="ldapServerType" />
 				</xsd:sequence>
 			</xsd:extension>
@@ -443,27 +427,6 @@
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<xsd:simpleType name="googleAppsProvisioningType">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="UserAccounts" />
-			<xsd:enumeration value="Groups" />
-			<xsd:enumeration value="OrganizationUnits" />
-		</xsd:restriction>
-	</xsd:simpleType>
-
-	<xsd:complexType name="googleAppsServiceType">
-		<xsd:complexContent>
-			<xsd:extension base="serviceType">
-				<xsd:sequence>
-					<xsd:element name="apiCategory" type="googleAppsProvisioningType"
-						default="UserAccounts" />
-					<xsd:element name="quotaLimitInMb" type="xsd:int"
-						minOccurs="0" default="25000" />
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-
 	<xsd:complexType name="pluginDestinationServiceType">
 		<xsd:complexContent>
 			<xsd:extension base="serviceType">
@@ -513,14 +476,12 @@
 			<xsd:element name="syncHook" type="xsd:string" minOccurs="0" />
 			<xsd:choice>
 				<xsd:element name="databaseSourceService" type="databaseSourceServiceType" />
-				<xsd:element name="googleAppsSourceService" type="googleAppsServiceType" />
 				<xsd:element name="ldapSourceService" type="ldapSourceServiceType" />
 				<xsd:element name="asyncLdapSourceService" type="asyncLdapSourceServiceType" />
 				<xsd:element name="pluginSourceService" type="pluginSourceServiceType" />
 			</xsd:choice>
 			<xsd:choice>
 				<xsd:element name="databaseDestinationService" type="databaseDestinationServiceType" />
-				<xsd:element name="googleAppsDestinationService" type="googleAppsServiceType" />
 				<xsd:element name="ldapDestinationService" type="ldapDestinationServiceType" />
 				<xsd:element name="multiDestinationService" type="multiDestinationServiceType" />
 				<xsd:element name="xaFileDestinationService" type="xaFileDestinationServiceType" />
@@ -535,12 +496,6 @@
 				minOccurs="0" />
 			<xsd:element name="scriptInclude" type="valuesType"
 				minOccurs="0" />
-			<!-- The following element is unsupported at this time -->
-			<xsd:element name="auditLog" minOccurs="0" maxOccurs="unbounded">
-				<xsd:complexType>
-					<xsd:attribute name="reference" type="xsd:IDREF" use="required" />
-				</xsd:complexType>
-			</xsd:element>
 		</xsd:sequence>
 		<xsd:attribute name="id" type="xsd:string" use="optional" />
 	</xsd:complexType>
@@ -549,21 +504,11 @@
 		<xsd:choice minOccurs="0" maxOccurs="unbounded">
 			<xsd:element name="ldapConnection" type="ldapConnectionType" />
 			<xsd:element name="databaseConnection" type="databaseConnectionType" />
-			<xsd:element name="googleAppsConnection" type="googleAppsConnectionType" />
 			<xsd:element name="pluginConnection" type="pluginConnectionType" />
 		</xsd:choice>
 		<xsd:attribute name="id" type="xsd:string" use="optional" />
 		<!-- Connection id uniqueness <xs:key name="uniqueConnectionIdentifier"> 
 			<xs:selector xpath="connection"/> <xs:field xpath="@name"/> </xs:key> -->
-	</xsd:complexType>
-
-	<xsd:complexType name="auditsType">
-		<xsd:choice minOccurs="0" maxOccurs="unbounded">
-			<xsd:element name="csvAudit" type="csvAuditType" />
-			<xsd:element name="ldifAudit" type="ldifAuditType" />
-			<xsd:element name="pluginAudit" type="pluginAuditType" />
-		</xsd:choice>
-		<xsd:attribute name="id" type="xsd:string" use="optional" />
 	</xsd:complexType>
 
 	<xsd:complexType name="tasksType">
@@ -600,7 +545,6 @@
 		<xsd:complexType>
 			<xsd:all>
 				<xsd:element name="connections" type="connectionsType" />
-				<xsd:element name="audits" type="auditsType" minOccurs="0" />
 				<xsd:element name="tasks" type="tasksType" />
 				<xsd:element name="security" type="securityType"
 					minOccurs="0" />

--- a/src/main/resources/schemas/lsc-microsoft-graph-api-plugin-1.0.xsd
+++ b/src/main/resources/schemas/lsc-microsoft-graph-api-plugin-1.0.xsd
@@ -2,9 +2,9 @@
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns="http://lsc-project.org/XSD/lsc-microsoft-graph-api-plugin-1.0.xsd" targetNamespace="http://lsc-project.org/XSD/lsc-microsoft-graph-api-plugin-1.0.xsd"
 	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	xmlns:lsc="http://lsc-project.org/XSD/lsc-core-2.1.xsd" jaxb:version="2.0">
+	xmlns:lsc="http://lsc-project.org/XSD/lsc-core-2.2.xsd" jaxb:version="2.0">
 
-	<xsd:import namespace="http://lsc-project.org/XSD/lsc-core-2.1.xsd" schemaLocation="lsc-core-2.1.xsd" />
+	<xsd:import namespace="http://lsc-project.org/XSD/lsc-core-2.2.xsd" schemaLocation="lsc-core-2.2.xsd" />
 
 	<xsd:element name="msGraphApiConnectionSettings">
 		<xsd:complexType>


### PR DESCRIPTION
Hello folks, working my way through setting up LSC and discovered that the recent changes for 2.2 support here aren't quite complete - if I use the 2.2 XSD schema for the root document, when I try to put this <name> tag...


```
<msgraphapi:msGraphApiUsersService>
                    <name>msgraphapi-users-service-src</name>
```

it complains that it's a 2.2 name tag instead of the expected 2.1 name tag. This PR seems to have fixed this, I can build and get a passing configuration test using something very similar to your sample XMLs. 

Not a Java developer btw, this is just search-n-replace - if I've done anything wrong here, lmk!